### PR TITLE
Add localized Discount All video embeds and validation

### DIFF
--- a/guides/de/essentials/discount/discount-all.mdx
+++ b/guides/de/essentials/discount/discount-all.mdx
@@ -4,6 +4,15 @@ description: "Mehrere Rabattarten zusammen anwenden, z. B. Bestell-, Produkt- 
 icon: "badge-percent"
 ---
 
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/rMxzgfTk2go?si=WFWg2ak0oGHEy2ms"
+  title="BeSure Alles rabattieren"
+  style={{ border: 0 }}
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
 ## Regelübersicht
 
 Mit dieser Regel können Sie mehrere Rabattarten gleichzeitig basierend auf definierten Bedingungen anwenden. Sie können Bestell-, Produkt- und Versandrabatte innerhalb einer einzigen Regel kombinieren, je nach den konfigurierten Kriterien. Jede Rabattart kann individuell angepasst werden, um einen prozentualen Nachlass, einen festen Betrag oder andere unterstützte Rabattformate anzuwenden.

--- a/guides/en/essentials/discount/discount-all.mdx
+++ b/guides/en/essentials/discount/discount-all.mdx
@@ -4,6 +4,15 @@ description: "Discount multiple types together, e-g, order or product or shippin
 icon: "badge-percent"
 ---
 
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/rMxzgfTk2go?si=WFWg2ak0oGHEy2ms"
+  title="BeSure Discount All"
+  style={{ border: 0 }}
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
 ## Rule overview
 
 This rule allows you to apply multiple types of discounts together based on defined conditions. You can combine order, product, and shipping discounts within a single rule, depending on the configured criteria. Each discount type can be customized to apply a percentage reduction, a fixed amount off, or other supported discount formats.

--- a/guides/es/essentials/discount/discount-all.mdx
+++ b/guides/es/essentials/discount/discount-all.mdx
@@ -4,6 +4,15 @@ description: "Aplica múltiples tipos de descuento juntos, por ejemplo, sobre el
 icon: "badge-percent"
 ---
 
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/rMxzgfTk2go?si=WFWg2ak0oGHEy2ms"
+  title="BeSure Descuento general"
+  style={{ border: 0 }}
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
 ## Resumen de la regla
 
 Esta regla te permite aplicar múltiples tipos de descuentos juntos según las condiciones definidas. Puedes combinar descuentos de pedido, producto y envío dentro de una sola regla, dependiendo de los criterios configurados. Cada tipo de descuento se puede personalizar para aplicar una reducción porcentual, un monto fijo de descuento u otros formatos de descuento compatibles.

--- a/guides/fr/essentials/discount/discount-all.mdx
+++ b/guides/fr/essentials/discount/discount-all.mdx
@@ -4,6 +4,15 @@ description: "Appliquez plusieurs types de remises ensemble, par exemple sur la 
 icon: "badge-percent"
 ---
 
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/rMxzgfTk2go?si=WFWg2ak0oGHEy2ms"
+  title="BeSure Remise globale"
+  style={{ border: 0 }}
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
 ## Aperçu de la règle
 
 Cette règle vous permet d’appliquer plusieurs types de remises ensemble en fonction des conditions définies. Vous pouvez combiner des remises sur la commande, le produit et la livraison au sein d’une seule règle, selon les critères configurés. Chaque type de remise peut être personnalisé pour appliquer un pourcentage de réduction, un montant fixe ou d’autres formats de remise pris en charge.

--- a/guides/ja/essentials/discount/discount-all.mdx
+++ b/guides/ja/essentials/discount/discount-all.mdx
@@ -4,6 +4,15 @@ description: "指定された条件に基づき、注文・商品・配送など
 icon: "badge-percent"
 ---
 
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/rMxzgfTk2go?si=WFWg2ak0oGHEy2ms"
+  title="BeSure すべて割引"
+  style={{ border: 0 }}
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
 ## ルール概要
 
 このルールでは、定義された条件に基づいて、複数の種類の割引を同時に適用できます。設定した条件に応じて、注文割引、商品割引、配送割引を1つのルール内で組み合わせることが可能です。各割引タイプは、パーセンテージ割引、固定金額割引、または対応しているその他の割引形式で個別に設定できます。

--- a/guides/zh/essentials/discount/discount-all.mdx
+++ b/guides/zh/essentials/discount/discount-all.mdx
@@ -4,6 +4,15 @@ description: "根据给定条件，对订单、产品或运费等多种类型同
 icon: "badge-percent"
 ---
 
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/rMxzgfTk2go?si=WFWg2ak0oGHEy2ms"
+  title="BeSure 全部折扣"
+  style={{ border: 0 }}
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
 ## 规则概览
 
 此规则允许您根据定义的条件，同时应用多种类型的折扣。您可以在单个规则中组合订单折扣、产品折扣和运费折扣，具体取决于配置的条件。每种折扣类型都可以自定义为百分比折扣、固定金额折扣或其他支持的折扣形式。

--- a/scripts/sync-to-gleap.js
+++ b/scripts/sync-to-gleap.js
@@ -20,14 +20,14 @@
  *                             If unset, derived from DOCS_BASE_URL only when hostname starts with "docs."
  */
 
-import { readFileSync, existsSync } from "node:fs";
-import { resolve, dirname, relative, isAbsolute } from "node:path";
-import { createHash } from "node:crypto";
-import { fileURLToPath } from "node:url";
+import { decodeHTML } from "entities";
 import matter from "gray-matter";
 import { marked } from "marked";
-import { decodeHTML } from "entities";
 import { parse } from "node-html-parser";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
## Summary
- add the new Discount All YouTube iframe to every localized `discount-all` guide using the existing repo iframe pattern
- translate the iframe `title` in English, Spanish, French, German, Japanese, and Chinese
- keep the required organize-imports pass by normalizing import order in `scripts/sync-to-gleap.js`

## Root Cause
The `discount-all` documentation pages were the only localized discount guides missing the standard opening video embed, so the new video was not surfaced to readers at all.

## Changes Made
- inserted the new YouTube iframe at the top of:
  - `guides/en/essentials/discount/discount-all.mdx`
  - `guides/es/essentials/discount/discount-all.mdx`
  - `guides/fr/essentials/discount/discount-all.mdx`
  - `guides/de/essentials/discount/discount-all.mdx`
  - `guides/ja/essentials/discount/discount-all.mdx`
  - `guides/zh/essentials/discount/discount-all.mdx`
- localized each iframe `title` to match the repo convention of `BeSure <localized rule name>`
- ran organize-imports, which reordered imports in `scripts/sync-to-gleap.js`

## Why This Is Necessary
Adding the video only to English would leave the localized docs inconsistent, and adding it with raw embed HTML would drift from the repo's established MDX iframe format.

## Validation
- `node --check scripts/sync-to-gleap.js`
- `git diff --check`
- `npx --yes organize-imports-cli scripts/sync-to-gleap.js`
- `npm test` currently fails because the repository's existing test script is still the default placeholder: `echo "Error: no test specified" && exit 1`

## Notes
- This repo currently has no TypeScript source files, no typecheck script, and no ESLint/Prettier configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; the only code change is import reordering in `scripts/sync-to-gleap.js`, which should not affect runtime behavior.
> 
> **Overview**
> Adds a consistent opening YouTube `iframe` embed (with localized `title`) to the `discount-all.mdx` guides for `en`, `es`, `fr`, `de`, `ja`, and `zh`.
> 
> Separately reorders imports in `scripts/sync-to-gleap.js` (no functional logic changes) to satisfy import-organization conventions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac55077dc0614dd08ef6e05e56d1df718ea40e10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added embedded video tutorials to the discount guides across all supported languages (English, Spanish, French, German, Japanese, and Chinese) to enhance learning resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->