### PR TITLE
Update checkout and setup-node GitHub Actions to v6

### DIFF
--- a/.github/workflows/sync-gleap.yml
+++ b/.github/workflows/sync-gleap.yml
@@ -34,10 +34,10 @@ jobs:
       DOCS_BASE_URL: ${{ vars.DOCS_BASE_URL }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary

Update the `Sync Gleap Help Center` workflow to use the current major versions of the core GitHub-maintained actions it depends on:

- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/setup-node@v4` -> `actions/setup-node@v6`

## Context

This repository's only workflow using these actions was still pinned to `v4`. The upstream action maintainers have since released newer major versions with runtime and behavior changes. Leaving the workflow on older majors increases the chance of future compatibility drift and delays adoption of the supported action line.

I reviewed the upstream release notes before making the change to confirm whether the migration is safe for this workflow's actual usage.

## Why this upgrade is safe here

### `actions/checkout@v6`

The main migration concern in `checkout@v6` is persisted credential handling and the related note about authenticated git commands from Docker container actions requiring a newer runner. That does not apply here because:

- this workflow runs on GitHub-hosted `ubuntu-latest`
- the repository does not define Docker-based actions
- the workflow does not run authenticated follow-up git commands after checkout

### `actions/setup-node@v6`

The main `setup-node@v6` behavior changes are around automatic npm caching and removal of the `always-auth` input. Those do not change this workflow's behavior because:

- the workflow already sets `cache: npm` explicitly
- the workflow does not use `always-auth`
- the workflow already targets Node.js `22`

## Changes made

- bumped `actions/checkout` from `v4` to `v6`
- bumped `actions/setup-node` from `v4` to `v6`
- left the rest of the workflow unchanged to keep the migration isolated

## Validation

- confirmed `.github/workflows/sync-gleap.yml` is the only workflow using these actions
- confirmed there are no local custom actions or Docker-based action usages that would make `checkout@v6` risky here
- ran `git diff --check`
- ran `node --check scripts/sync-to-gleap.js`

## Validation gaps / repo state

- there are no TypeScript files in this repository
- there is no ESLint config in the repository
- there is no Prettier config in the repository
- `npm test` fails on the existing placeholder script in `package.json` (`echo "Error: no test specified" && exit 1`), which is already the current behavior on `main`
- `organize-imports` was attempted via `npx`, but the CLI is not installed locally and requires external package resolution in this environment; no source-file diff was introduced beyond the workflow version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Actions versions in a single workflow, with no application code or runtime behavior changes beyond upstream action implementation differences.
> 
> **Overview**
> Updates the `Sync Gleap Help Center` workflow to use `actions/checkout@v6` and `actions/setup-node@v6` (from `v4`), keeping the rest of the job steps and Node 22/npm cache settings unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e576ffc0a361d688edcd617d00d7edbfc779e180. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to use newer action versions for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->