### PR TITLE
Use pnpm for Gleap sync workflow

### DIFF
--- a/.github/workflows/sync-gleap.yml
+++ b/.github/workflows/sync-gleap.yml
@@ -11,7 +11,8 @@ on:
       - "images/**"
       - "scripts/sync-to-gleap.js"
       - "package.json"
-      - "package-lock.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - ".github/workflows/sync-gleap.yml"
   workflow_dispatch:
 
@@ -36,14 +37,19 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
-          cache: npm
+          node-version: 24
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+        run: pnpm install --frozen-lockfile
 
       - name: Ensure required secrets are present
         run: |
@@ -51,7 +57,7 @@ jobs:
           test -n "$GLEAP_PROJECT_ID"
 
       - name: Sync docs to Gleap
-        run: npm run sync-gleap
+        run: pnpm run sync-gleap
 
       - name: Print success message
         run: echo "Sync completed successfully"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "description": "This is the documentation for the Checkout Rules App.",
   "main": "index.js",
+  "packageManager": "pnpm@11.2.2",
+  "engines": {
+    "node": ">=24.0.0",
+    "pnpm": ">=11 <12"
+  },
   "scripts": {
     "dev": "mint dev",
     "validate": "mint validate",

--- a/scripts/sync-to-gleap.js
+++ b/scripts/sync-to-gleap.js
@@ -8,7 +8,7 @@
  *
  * Usage:
  *   node scripts/sync-to-gleap.js
- *   npm run sync-gleap
+ *   pnpm run sync-gleap
  *
  * Required env vars (set in .env or environment):
  *   GLEAP_API_KEY      — Gleap API key (Project Settings → Security → API Key)


### PR DESCRIPTION
## Root cause
The Gleap sync workflow still assumed npm after the project moved from package-lock.json to pnpm-lock.yaml. It watched package-lock.json, used npm cache, ran npm ci, and invoked npm run sync-gleap, so the workflow would fail without the npm lockfile.

## Changes
- Install pnpm in .github/workflows/sync-gleap.yml with pnpm/action-setup@v6.
- Use Node 24 with pnpm caching in actions/setup-node@v6.
- Watch pnpm-lock.yaml and pnpm-workspace.yaml instead of package-lock.json.
- Install dependencies with pnpm install --frozen-lockfile and run pnpm run sync-gleap.
- Add packageManager pnpm@11.2.2 and Node/pnpm engines to package.json.
- Update the sync script usage comment from npm to pnpm.

## Validation
- corepack pnpm --version returned 11.2.2.
- corepack pnpm install --lockfile-only passed with no pnpm-lock.yaml changes needed.
- corepack pnpm install --frozen-lockfile passed.
- corepack pnpm run validate passed.
- Workflow YAML parse check passed.
- node --check scripts/sync-to-gleap.js passed.

Note: I did not run the live Gleap sync because it requires production Gleap secrets and API access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and tooling metadata only; Gleap sync behavior is unchanged aside from how dependencies are installed.
> 
> **Overview**
> Aligns the **Gleap Help Center sync** GitHub Action with the repo’s **pnpm** lockfiles after the move away from npm.
> 
> The workflow now installs **pnpm** (`pnpm/action-setup@v6`), uses **Node 24** with **pnpm** caching, watches `pnpm-lock.yaml` and `pnpm-workspace.yaml` instead of `package-lock.json`, runs `pnpm install --frozen-lockfile` (with `PUPPETEER_SKIP_DOWNLOAD=true`), and invokes `pnpm run sync-gleap`. **`package.json`** declares `packageManager: pnpm@11.2.2` and **engines** for Node ≥24 and pnpm 11.x. The sync script header comment documents **pnpm** usage instead of npm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c599c833cce39449f76354a9d5923eaa94da46a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the sync workflow to use pnpm and Node.js 24 for dependency installation and execution.
  * Adjusted project requirements to reflect the supported Node.js and pnpm versions.
  * Updated the sync command reference to use the current package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->