### PR TITLE
Show condition set 7 on concepts pages

### DIFF
--- a/guides/de/get-started/concepts.mdx
+++ b/guides/de/get-started/concepts.mdx
@@ -94,6 +94,13 @@ Weitere Informationen zu Bedingungssets finden Sie [hier](/guides/de/essentials/
   >
     Erfahren Sie mehr über Bedingungsset 6.
   </Card>
+  <Card
+    title="Bedingungsset 7"
+    icon="7"
+    href="/guides/de/essentials/condition-sets/condition-set-7"
+  >
+    Erfahren Sie mehr über Bedingungsset 7.
+  </Card>
 </CardGroup>
 
 ### Bedingungen (das "wann")

--- a/guides/en/get-started/concepts.mdx
+++ b/guides/en/get-started/concepts.mdx
@@ -98,6 +98,13 @@ Get more information about condition sets [here](/guides/en/essentials/condition
   >
     Learn more about condition set 6.
   </Card>
+  <Card
+    title="Condition Set 7"
+    icon="7"
+    href="/guides/en/essentials/condition-sets/condition-set-7"
+  >
+    Learn more about condition set 7.
+  </Card>
 </CardGroup>
 
 ### Conditions (the "when")

--- a/guides/es/get-started/concepts.mdx
+++ b/guides/es/get-started/concepts.mdx
@@ -98,6 +98,13 @@ Obtén más información sobre conjuntos de condiciones [aquí](/guides/es/essen
   >
     Aprende más sobre el conjunto de condiciones 6.
   </Card>
+  <Card
+    title="Conjunto de Condiciones 7"
+    icon="7"
+    href="/guides/es/essentials/condition-sets/condition-set-7"
+  >
+    Aprende más sobre el conjunto de condiciones 7.
+  </Card>
 </CardGroup>
 
 ### Condiciones (el "cuándo")

--- a/guides/fr/get-started/concepts.mdx
+++ b/guides/fr/get-started/concepts.mdx
@@ -99,6 +99,13 @@ Obtenez plus d’informations sur les ensembles de conditions [ici](/guides/fr/e
   >
     En savoir plus sur l’ensemble de conditions 6.
   </Card>
+  <Card
+    title="Ensemble de conditions 7"
+    icon="7"
+    href="/guides/fr/essentials/condition-sets/condition-set-7"
+  >
+    En savoir plus sur l’ensemble de conditions 7.
+  </Card>
 </CardGroup>
 
 ### Conditions (le « quand »)

--- a/guides/ja/get-started/concepts.mdx
+++ b/guides/ja/get-started/concepts.mdx
@@ -94,6 +94,13 @@ icon: "puzzle-piece"
   >
     コンディションセット6について詳しく学ぶ。
   </Card>
+  <Card
+    title="コンディションセット 7"
+    icon="7"
+    href="/guides/ja/essentials/condition-sets/condition-set-7"
+  >
+    コンディションセット7について詳しく学ぶ。
+  </Card>
 </CardGroup>
 
 ### コンディション（「いつ」）

--- a/guides/zh/get-started/concepts.mdx
+++ b/guides/zh/get-started/concepts.mdx
@@ -94,6 +94,13 @@ icon: "puzzle-piece"
   >
     了解更多关于条件集 6 的信息。
   </Card>
+  <Card
+    title="条件集 7"
+    icon="7"
+    href="/guides/zh/essentials/condition-sets/condition-set-7"
+  >
+    了解更多关于条件集 7 的信息。
+  </Card>
 </CardGroup>
 
 ### 条件（“何时”）


### PR DESCRIPTION
## Root cause

The concepts page card grid still only listed condition sets 1 through 6, even though condition set 7 documentation pages now exist for all locales.

## Changes

- Added a Condition Set 7 card to the English concepts page.
- Added matching translated Condition Set 7 cards to Spanish, French, German, Japanese, and Chinese concepts pages.
- Linked each card to the locale-specific `condition-set-7` page.

## Validation

- `./node_modules/.bin/mint validate`

Fixes CR-942

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only navigation updates with no application or runtime impact.
> 
> **Overview**
> Adds a **Condition Set 7** navigation card to the condition-set `CardGroup` on each locale’s **Concepts** page (`guides/{de,en,es,fr,ja,zh}/get-started/concepts.mdx`), matching the existing cards for sets 1–6.
> 
> Each new card uses icon `7` and links to that locale’s `condition-set-7` essentials page so readers can discover the new set from the concepts overview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0f36430277603f75dc44a78bebe58df84d4c0d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Condition Set 7” card to the Concepts/Condition Set guide in multiple languages.
  * Included the corresponding title, icon, and link so users can access the new documentation entry more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->